### PR TITLE
Loader Cache Decorators

### DIFF
--- a/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
+++ b/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		600FBACF2969676E00AF7D06 /* FeedImageDataLoaderCacheDecoratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600FBACE2969676E00AF7D06 /* FeedImageDataLoaderCacheDecoratorTests.swift */; };
 		600FBAD129696C6900AF7D06 /* FeedImageDataLoaderSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600FBAD029696C6900AF7D06 /* FeedImageDataLoaderSpy.swift */; };
 		600FBAD329696D1100AF7D06 /* XCTestCase+FeedImageDataLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600FBAD229696D1100AF7D06 /* XCTestCase+FeedImageDataLoader.swift */; };
+		600FBAD72969812800AF7D06 /* FeedImageDataLoaderCacheDecorator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600FBAD62969812800AF7D06 /* FeedImageDataLoaderCacheDecorator.swift */; };
 		6041947327CA807C0078DAF9 /* FeedLoaderWithFallbackComposite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6041947227CA807C0078DAF9 /* FeedLoaderWithFallbackComposite.swift */; };
 		6041947527CA86DE0078DAF9 /* FeedImageDataLoaderWithFallbackCompositeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6041947427CA86DE0078DAF9 /* FeedImageDataLoaderWithFallbackCompositeTests.swift */; };
 		6071D53F27C69601005AAB91 /* EssentialFeed.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6071D53D27C69601005AAB91 /* EssentialFeed.framework */; };
@@ -66,6 +67,7 @@
 		600FBACE2969676E00AF7D06 /* FeedImageDataLoaderCacheDecoratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoaderCacheDecoratorTests.swift; sourceTree = "<group>"; };
 		600FBAD029696C6900AF7D06 /* FeedImageDataLoaderSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoaderSpy.swift; sourceTree = "<group>"; };
 		600FBAD229696D1100AF7D06 /* XCTestCase+FeedImageDataLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+FeedImageDataLoader.swift"; sourceTree = "<group>"; };
+		600FBAD62969812800AF7D06 /* FeedImageDataLoaderCacheDecorator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoaderCacheDecorator.swift; sourceTree = "<group>"; };
 		6041947227CA807C0078DAF9 /* FeedLoaderWithFallbackComposite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderWithFallbackComposite.swift; sourceTree = "<group>"; };
 		6041947427CA86DE0078DAF9 /* FeedImageDataLoaderWithFallbackCompositeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoaderWithFallbackCompositeTests.swift; sourceTree = "<group>"; };
 		6071D53D27C69601005AAB91 /* EssentialFeed.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = EssentialFeed.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -154,6 +156,7 @@
 				6041947227CA807C0078DAF9 /* FeedLoaderWithFallbackComposite.swift */,
 				60BA15132967FB5D00F9603B /* FeedImageDataLoaderWithFallbackComposite.swift */,
 				600FBACC2969664000AF7D06 /* FeedLoaderCacheDecorator.swift */,
+				600FBAD62969812800AF7D06 /* FeedImageDataLoaderCacheDecorator.swift */,
 				60E3DEFB27C6933E00376750 /* Main.storyboard */,
 				60E3DEFE27C6934000376750 /* Assets.xcassets */,
 				60E3DF0027C6934000376750 /* LaunchScreen.storyboard */,
@@ -283,6 +286,7 @@
 				600FBACD2969664000AF7D06 /* FeedLoaderCacheDecorator.swift in Sources */,
 				60E3DEF827C6933E00376750 /* SceneDelegate.swift in Sources */,
 				60BA15142967FB5D00F9603B /* FeedImageDataLoaderWithFallbackComposite.swift in Sources */,
+				600FBAD72969812800AF7D06 /* FeedImageDataLoaderCacheDecorator.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
+++ b/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		6001982B27C9266F0041FF93 /* FeedLoaderWithFallbackCompositeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6001982A27C9266F0041FF93 /* FeedLoaderWithFallbackCompositeTests.swift */; };
 		600DDDBD2969572D00D984D8 /* FeedLoaderCacheDecoratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600DDDBC2969572D00D984D8 /* FeedLoaderCacheDecoratorTests.swift */; };
 		600DDDBF29695A0100D984D8 /* FeedLoaderStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600DDDBE29695A0100D984D8 /* FeedLoaderStub.swift */; };
+		600DDDC129695B0C00D984D8 /* XCTestCase+FeedLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600DDDC029695B0C00D984D8 /* XCTestCase+FeedLoader.swift */; };
 		6041947327CA807C0078DAF9 /* FeedLoaderWithFallbackComposite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6041947227CA807C0078DAF9 /* FeedLoaderWithFallbackComposite.swift */; };
 		6041947527CA86DE0078DAF9 /* FeedImageDataLoaderWithFallbackCompositeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6041947427CA86DE0078DAF9 /* FeedImageDataLoaderWithFallbackCompositeTests.swift */; };
 		6071D53F27C69601005AAB91 /* EssentialFeed.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6071D53D27C69601005AAB91 /* EssentialFeed.framework */; };
@@ -56,6 +57,7 @@
 		6001982A27C9266F0041FF93 /* FeedLoaderWithFallbackCompositeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderWithFallbackCompositeTests.swift; sourceTree = "<group>"; };
 		600DDDBC2969572D00D984D8 /* FeedLoaderCacheDecoratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderCacheDecoratorTests.swift; sourceTree = "<group>"; };
 		600DDDBE29695A0100D984D8 /* FeedLoaderStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderStub.swift; sourceTree = "<group>"; };
+		600DDDC029695B0C00D984D8 /* XCTestCase+FeedLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+FeedLoader.swift"; sourceTree = "<group>"; };
 		6041947227CA807C0078DAF9 /* FeedLoaderWithFallbackComposite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderWithFallbackComposite.swift; sourceTree = "<group>"; };
 		6041947427CA86DE0078DAF9 /* FeedImageDataLoaderWithFallbackCompositeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoaderWithFallbackCompositeTests.swift; sourceTree = "<group>"; };
 		6071D53D27C69601005AAB91 /* EssentialFeed.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = EssentialFeed.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -109,6 +111,7 @@
 				60BA15162967FC2600F9603B /* XCTestCase+MemoryLeakTracking.swift */,
 				60BA15182967FCD400F9603B /* SharedTestHelpers.swift */,
 				600DDDBE29695A0100D984D8 /* FeedLoaderStub.swift */,
+				600DDDC029695B0C00D984D8 /* XCTestCase+FeedLoader.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -275,6 +278,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				60BA15192967FCD400F9603B /* SharedTestHelpers.swift in Sources */,
+				600DDDC129695B0C00D984D8 /* XCTestCase+FeedLoader.swift in Sources */,
 				600DDDBD2969572D00D984D8 /* FeedLoaderCacheDecoratorTests.swift in Sources */,
 				6041947527CA86DE0078DAF9 /* FeedImageDataLoaderWithFallbackCompositeTests.swift in Sources */,
 				6001982B27C9266F0041FF93 /* FeedLoaderWithFallbackCompositeTests.swift in Sources */,

--- a/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
+++ b/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		6001982B27C9266F0041FF93 /* FeedLoaderWithFallbackCompositeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6001982A27C9266F0041FF93 /* FeedLoaderWithFallbackCompositeTests.swift */; };
+		600DDDBD2969572D00D984D8 /* FeedLoaderCacheDecoratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600DDDBC2969572D00D984D8 /* FeedLoaderCacheDecoratorTests.swift */; };
 		6041947327CA807C0078DAF9 /* FeedLoaderWithFallbackComposite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6041947227CA807C0078DAF9 /* FeedLoaderWithFallbackComposite.swift */; };
 		6041947527CA86DE0078DAF9 /* FeedImageDataLoaderWithFallbackCompositeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6041947427CA86DE0078DAF9 /* FeedImageDataLoaderWithFallbackCompositeTests.swift */; };
 		6071D53F27C69601005AAB91 /* EssentialFeed.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6071D53D27C69601005AAB91 /* EssentialFeed.framework */; };
@@ -52,6 +53,7 @@
 
 /* Begin PBXFileReference section */
 		6001982A27C9266F0041FF93 /* FeedLoaderWithFallbackCompositeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderWithFallbackCompositeTests.swift; sourceTree = "<group>"; };
+		600DDDBC2969572D00D984D8 /* FeedLoaderCacheDecoratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderCacheDecoratorTests.swift; sourceTree = "<group>"; };
 		6041947227CA807C0078DAF9 /* FeedLoaderWithFallbackComposite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderWithFallbackComposite.swift; sourceTree = "<group>"; };
 		6041947427CA86DE0078DAF9 /* FeedImageDataLoaderWithFallbackCompositeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoaderWithFallbackCompositeTests.swift; sourceTree = "<group>"; };
 		6071D53D27C69601005AAB91 /* EssentialFeed.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = EssentialFeed.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -146,9 +148,10 @@
 		60E3DF0B27C6934000376750 /* EssentialAppTests */ = {
 			isa = PBXGroup;
 			children = (
-				6001982A27C9266F0041FF93 /* FeedLoaderWithFallbackCompositeTests.swift */,
-				6041947427CA86DE0078DAF9 /* FeedImageDataLoaderWithFallbackCompositeTests.swift */,
 				60BA15152967FC0400F9603B /* Helpers */,
+				6001982A27C9266F0041FF93 /* FeedLoaderWithFallbackCompositeTests.swift */,
+				600DDDBC2969572D00D984D8 /* FeedLoaderCacheDecoratorTests.swift */,
+				6041947427CA86DE0078DAF9 /* FeedImageDataLoaderWithFallbackCompositeTests.swift */,
 			);
 			path = EssentialAppTests;
 			sourceTree = "<group>";
@@ -269,6 +272,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				60BA15192967FCD400F9603B /* SharedTestHelpers.swift in Sources */,
+				600DDDBD2969572D00D984D8 /* FeedLoaderCacheDecoratorTests.swift in Sources */,
 				6041947527CA86DE0078DAF9 /* FeedImageDataLoaderWithFallbackCompositeTests.swift in Sources */,
 				6001982B27C9266F0041FF93 /* FeedLoaderWithFallbackCompositeTests.swift in Sources */,
 				60BA15172967FC2600F9603B /* XCTestCase+MemoryLeakTracking.swift in Sources */,

--- a/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
+++ b/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		600DDDBD2969572D00D984D8 /* FeedLoaderCacheDecoratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600DDDBC2969572D00D984D8 /* FeedLoaderCacheDecoratorTests.swift */; };
 		600DDDBF29695A0100D984D8 /* FeedLoaderStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600DDDBE29695A0100D984D8 /* FeedLoaderStub.swift */; };
 		600DDDC129695B0C00D984D8 /* XCTestCase+FeedLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600DDDC029695B0C00D984D8 /* XCTestCase+FeedLoader.swift */; };
+		600FBACD2969664000AF7D06 /* FeedLoaderCacheDecorator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600FBACC2969664000AF7D06 /* FeedLoaderCacheDecorator.swift */; };
 		6041947327CA807C0078DAF9 /* FeedLoaderWithFallbackComposite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6041947227CA807C0078DAF9 /* FeedLoaderWithFallbackComposite.swift */; };
 		6041947527CA86DE0078DAF9 /* FeedImageDataLoaderWithFallbackCompositeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6041947427CA86DE0078DAF9 /* FeedImageDataLoaderWithFallbackCompositeTests.swift */; };
 		6071D53F27C69601005AAB91 /* EssentialFeed.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6071D53D27C69601005AAB91 /* EssentialFeed.framework */; };
@@ -58,6 +59,7 @@
 		600DDDBC2969572D00D984D8 /* FeedLoaderCacheDecoratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderCacheDecoratorTests.swift; sourceTree = "<group>"; };
 		600DDDBE29695A0100D984D8 /* FeedLoaderStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderStub.swift; sourceTree = "<group>"; };
 		600DDDC029695B0C00D984D8 /* XCTestCase+FeedLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+FeedLoader.swift"; sourceTree = "<group>"; };
+		600FBACC2969664000AF7D06 /* FeedLoaderCacheDecorator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderCacheDecorator.swift; sourceTree = "<group>"; };
 		6041947227CA807C0078DAF9 /* FeedLoaderWithFallbackComposite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderWithFallbackComposite.swift; sourceTree = "<group>"; };
 		6041947427CA86DE0078DAF9 /* FeedImageDataLoaderWithFallbackCompositeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoaderWithFallbackCompositeTests.swift; sourceTree = "<group>"; };
 		6071D53D27C69601005AAB91 /* EssentialFeed.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = EssentialFeed.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -143,6 +145,7 @@
 				60E3DEF927C6933E00376750 /* ViewController.swift */,
 				6041947227CA807C0078DAF9 /* FeedLoaderWithFallbackComposite.swift */,
 				60BA15132967FB5D00F9603B /* FeedImageDataLoaderWithFallbackComposite.swift */,
+				600FBACC2969664000AF7D06 /* FeedLoaderCacheDecorator.swift */,
 				60E3DEFB27C6933E00376750 /* Main.storyboard */,
 				60E3DEFE27C6934000376750 /* Assets.xcassets */,
 				60E3DF0027C6934000376750 /* LaunchScreen.storyboard */,
@@ -268,6 +271,7 @@
 				60E3DEFA27C6933E00376750 /* ViewController.swift in Sources */,
 				60E3DEF627C6933E00376750 /* AppDelegate.swift in Sources */,
 				6041947327CA807C0078DAF9 /* FeedLoaderWithFallbackComposite.swift in Sources */,
+				600FBACD2969664000AF7D06 /* FeedLoaderCacheDecorator.swift in Sources */,
 				60E3DEF827C6933E00376750 /* SceneDelegate.swift in Sources */,
 				60BA15142967FB5D00F9603B /* FeedImageDataLoaderWithFallbackComposite.swift in Sources */,
 			);

--- a/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
+++ b/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		600FBACD2969664000AF7D06 /* FeedLoaderCacheDecorator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600FBACC2969664000AF7D06 /* FeedLoaderCacheDecorator.swift */; };
 		600FBACF2969676E00AF7D06 /* FeedImageDataLoaderCacheDecoratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600FBACE2969676E00AF7D06 /* FeedImageDataLoaderCacheDecoratorTests.swift */; };
 		600FBAD129696C6900AF7D06 /* FeedImageDataLoaderSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600FBAD029696C6900AF7D06 /* FeedImageDataLoaderSpy.swift */; };
+		600FBAD329696D1100AF7D06 /* XCTestCase+FeedImageDataLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600FBAD229696D1100AF7D06 /* XCTestCase+FeedImageDataLoader.swift */; };
 		6041947327CA807C0078DAF9 /* FeedLoaderWithFallbackComposite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6041947227CA807C0078DAF9 /* FeedLoaderWithFallbackComposite.swift */; };
 		6041947527CA86DE0078DAF9 /* FeedImageDataLoaderWithFallbackCompositeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6041947427CA86DE0078DAF9 /* FeedImageDataLoaderWithFallbackCompositeTests.swift */; };
 		6071D53F27C69601005AAB91 /* EssentialFeed.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6071D53D27C69601005AAB91 /* EssentialFeed.framework */; };
@@ -64,6 +65,7 @@
 		600FBACC2969664000AF7D06 /* FeedLoaderCacheDecorator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderCacheDecorator.swift; sourceTree = "<group>"; };
 		600FBACE2969676E00AF7D06 /* FeedImageDataLoaderCacheDecoratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoaderCacheDecoratorTests.swift; sourceTree = "<group>"; };
 		600FBAD029696C6900AF7D06 /* FeedImageDataLoaderSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoaderSpy.swift; sourceTree = "<group>"; };
+		600FBAD229696D1100AF7D06 /* XCTestCase+FeedImageDataLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+FeedImageDataLoader.swift"; sourceTree = "<group>"; };
 		6041947227CA807C0078DAF9 /* FeedLoaderWithFallbackComposite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderWithFallbackComposite.swift; sourceTree = "<group>"; };
 		6041947427CA86DE0078DAF9 /* FeedImageDataLoaderWithFallbackCompositeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoaderWithFallbackCompositeTests.swift; sourceTree = "<group>"; };
 		6071D53D27C69601005AAB91 /* EssentialFeed.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = EssentialFeed.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -119,6 +121,7 @@
 				600DDDBE29695A0100D984D8 /* FeedLoaderStub.swift */,
 				600DDDC029695B0C00D984D8 /* XCTestCase+FeedLoader.swift */,
 				600FBAD029696C6900AF7D06 /* FeedImageDataLoaderSpy.swift */,
+				600FBAD229696D1100AF7D06 /* XCTestCase+FeedImageDataLoader.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -290,6 +293,7 @@
 				60BA15192967FCD400F9603B /* SharedTestHelpers.swift in Sources */,
 				600FBACF2969676E00AF7D06 /* FeedImageDataLoaderCacheDecoratorTests.swift in Sources */,
 				600DDDC129695B0C00D984D8 /* XCTestCase+FeedLoader.swift in Sources */,
+				600FBAD329696D1100AF7D06 /* XCTestCase+FeedImageDataLoader.swift in Sources */,
 				600DDDBD2969572D00D984D8 /* FeedLoaderCacheDecoratorTests.swift in Sources */,
 				600FBAD129696C6900AF7D06 /* FeedImageDataLoaderSpy.swift in Sources */,
 				6041947527CA86DE0078DAF9 /* FeedImageDataLoaderWithFallbackCompositeTests.swift in Sources */,

--- a/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
+++ b/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		6001982B27C9266F0041FF93 /* FeedLoaderWithFallbackCompositeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6001982A27C9266F0041FF93 /* FeedLoaderWithFallbackCompositeTests.swift */; };
 		600DDDBD2969572D00D984D8 /* FeedLoaderCacheDecoratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600DDDBC2969572D00D984D8 /* FeedLoaderCacheDecoratorTests.swift */; };
+		600DDDBF29695A0100D984D8 /* FeedLoaderStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600DDDBE29695A0100D984D8 /* FeedLoaderStub.swift */; };
 		6041947327CA807C0078DAF9 /* FeedLoaderWithFallbackComposite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6041947227CA807C0078DAF9 /* FeedLoaderWithFallbackComposite.swift */; };
 		6041947527CA86DE0078DAF9 /* FeedImageDataLoaderWithFallbackCompositeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6041947427CA86DE0078DAF9 /* FeedImageDataLoaderWithFallbackCompositeTests.swift */; };
 		6071D53F27C69601005AAB91 /* EssentialFeed.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6071D53D27C69601005AAB91 /* EssentialFeed.framework */; };
@@ -54,6 +55,7 @@
 /* Begin PBXFileReference section */
 		6001982A27C9266F0041FF93 /* FeedLoaderWithFallbackCompositeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderWithFallbackCompositeTests.swift; sourceTree = "<group>"; };
 		600DDDBC2969572D00D984D8 /* FeedLoaderCacheDecoratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderCacheDecoratorTests.swift; sourceTree = "<group>"; };
+		600DDDBE29695A0100D984D8 /* FeedLoaderStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderStub.swift; sourceTree = "<group>"; };
 		6041947227CA807C0078DAF9 /* FeedLoaderWithFallbackComposite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderWithFallbackComposite.swift; sourceTree = "<group>"; };
 		6041947427CA86DE0078DAF9 /* FeedImageDataLoaderWithFallbackCompositeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoaderWithFallbackCompositeTests.swift; sourceTree = "<group>"; };
 		6071D53D27C69601005AAB91 /* EssentialFeed.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = EssentialFeed.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -106,6 +108,7 @@
 			children = (
 				60BA15162967FC2600F9603B /* XCTestCase+MemoryLeakTracking.swift */,
 				60BA15182967FCD400F9603B /* SharedTestHelpers.swift */,
+				600DDDBE29695A0100D984D8 /* FeedLoaderStub.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -150,8 +153,8 @@
 			children = (
 				60BA15152967FC0400F9603B /* Helpers */,
 				6001982A27C9266F0041FF93 /* FeedLoaderWithFallbackCompositeTests.swift */,
-				600DDDBC2969572D00D984D8 /* FeedLoaderCacheDecoratorTests.swift */,
 				6041947427CA86DE0078DAF9 /* FeedImageDataLoaderWithFallbackCompositeTests.swift */,
+				600DDDBC2969572D00D984D8 /* FeedLoaderCacheDecoratorTests.swift */,
 			);
 			path = EssentialAppTests;
 			sourceTree = "<group>";
@@ -275,6 +278,7 @@
 				600DDDBD2969572D00D984D8 /* FeedLoaderCacheDecoratorTests.swift in Sources */,
 				6041947527CA86DE0078DAF9 /* FeedImageDataLoaderWithFallbackCompositeTests.swift in Sources */,
 				6001982B27C9266F0041FF93 /* FeedLoaderWithFallbackCompositeTests.swift in Sources */,
+				600DDDBF29695A0100D984D8 /* FeedLoaderStub.swift in Sources */,
 				60BA15172967FC2600F9603B /* XCTestCase+MemoryLeakTracking.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
+++ b/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		600DDDC129695B0C00D984D8 /* XCTestCase+FeedLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600DDDC029695B0C00D984D8 /* XCTestCase+FeedLoader.swift */; };
 		600FBACD2969664000AF7D06 /* FeedLoaderCacheDecorator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600FBACC2969664000AF7D06 /* FeedLoaderCacheDecorator.swift */; };
 		600FBACF2969676E00AF7D06 /* FeedImageDataLoaderCacheDecoratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600FBACE2969676E00AF7D06 /* FeedImageDataLoaderCacheDecoratorTests.swift */; };
+		600FBAD129696C6900AF7D06 /* FeedImageDataLoaderSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600FBAD029696C6900AF7D06 /* FeedImageDataLoaderSpy.swift */; };
 		6041947327CA807C0078DAF9 /* FeedLoaderWithFallbackComposite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6041947227CA807C0078DAF9 /* FeedLoaderWithFallbackComposite.swift */; };
 		6041947527CA86DE0078DAF9 /* FeedImageDataLoaderWithFallbackCompositeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6041947427CA86DE0078DAF9 /* FeedImageDataLoaderWithFallbackCompositeTests.swift */; };
 		6071D53F27C69601005AAB91 /* EssentialFeed.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6071D53D27C69601005AAB91 /* EssentialFeed.framework */; };
@@ -62,6 +63,7 @@
 		600DDDC029695B0C00D984D8 /* XCTestCase+FeedLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+FeedLoader.swift"; sourceTree = "<group>"; };
 		600FBACC2969664000AF7D06 /* FeedLoaderCacheDecorator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderCacheDecorator.swift; sourceTree = "<group>"; };
 		600FBACE2969676E00AF7D06 /* FeedImageDataLoaderCacheDecoratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoaderCacheDecoratorTests.swift; sourceTree = "<group>"; };
+		600FBAD029696C6900AF7D06 /* FeedImageDataLoaderSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoaderSpy.swift; sourceTree = "<group>"; };
 		6041947227CA807C0078DAF9 /* FeedLoaderWithFallbackComposite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderWithFallbackComposite.swift; sourceTree = "<group>"; };
 		6041947427CA86DE0078DAF9 /* FeedImageDataLoaderWithFallbackCompositeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoaderWithFallbackCompositeTests.swift; sourceTree = "<group>"; };
 		6071D53D27C69601005AAB91 /* EssentialFeed.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = EssentialFeed.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -116,6 +118,7 @@
 				60BA15182967FCD400F9603B /* SharedTestHelpers.swift */,
 				600DDDBE29695A0100D984D8 /* FeedLoaderStub.swift */,
 				600DDDC029695B0C00D984D8 /* XCTestCase+FeedLoader.swift */,
+				600FBAD029696C6900AF7D06 /* FeedImageDataLoaderSpy.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -288,6 +291,7 @@
 				600FBACF2969676E00AF7D06 /* FeedImageDataLoaderCacheDecoratorTests.swift in Sources */,
 				600DDDC129695B0C00D984D8 /* XCTestCase+FeedLoader.swift in Sources */,
 				600DDDBD2969572D00D984D8 /* FeedLoaderCacheDecoratorTests.swift in Sources */,
+				600FBAD129696C6900AF7D06 /* FeedImageDataLoaderSpy.swift in Sources */,
 				6041947527CA86DE0078DAF9 /* FeedImageDataLoaderWithFallbackCompositeTests.swift in Sources */,
 				6001982B27C9266F0041FF93 /* FeedLoaderWithFallbackCompositeTests.swift in Sources */,
 				600DDDBF29695A0100D984D8 /* FeedLoaderStub.swift in Sources */,

--- a/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
+++ b/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		600DDDBF29695A0100D984D8 /* FeedLoaderStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600DDDBE29695A0100D984D8 /* FeedLoaderStub.swift */; };
 		600DDDC129695B0C00D984D8 /* XCTestCase+FeedLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600DDDC029695B0C00D984D8 /* XCTestCase+FeedLoader.swift */; };
 		600FBACD2969664000AF7D06 /* FeedLoaderCacheDecorator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600FBACC2969664000AF7D06 /* FeedLoaderCacheDecorator.swift */; };
+		600FBACF2969676E00AF7D06 /* FeedImageDataLoaderCacheDecoratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600FBACE2969676E00AF7D06 /* FeedImageDataLoaderCacheDecoratorTests.swift */; };
 		6041947327CA807C0078DAF9 /* FeedLoaderWithFallbackComposite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6041947227CA807C0078DAF9 /* FeedLoaderWithFallbackComposite.swift */; };
 		6041947527CA86DE0078DAF9 /* FeedImageDataLoaderWithFallbackCompositeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6041947427CA86DE0078DAF9 /* FeedImageDataLoaderWithFallbackCompositeTests.swift */; };
 		6071D53F27C69601005AAB91 /* EssentialFeed.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6071D53D27C69601005AAB91 /* EssentialFeed.framework */; };
@@ -60,6 +61,7 @@
 		600DDDBE29695A0100D984D8 /* FeedLoaderStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderStub.swift; sourceTree = "<group>"; };
 		600DDDC029695B0C00D984D8 /* XCTestCase+FeedLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+FeedLoader.swift"; sourceTree = "<group>"; };
 		600FBACC2969664000AF7D06 /* FeedLoaderCacheDecorator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderCacheDecorator.swift; sourceTree = "<group>"; };
+		600FBACE2969676E00AF7D06 /* FeedImageDataLoaderCacheDecoratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoaderCacheDecoratorTests.swift; sourceTree = "<group>"; };
 		6041947227CA807C0078DAF9 /* FeedLoaderWithFallbackComposite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderWithFallbackComposite.swift; sourceTree = "<group>"; };
 		6041947427CA86DE0078DAF9 /* FeedImageDataLoaderWithFallbackCompositeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoaderWithFallbackCompositeTests.swift; sourceTree = "<group>"; };
 		6071D53D27C69601005AAB91 /* EssentialFeed.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = EssentialFeed.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -161,6 +163,7 @@
 				6001982A27C9266F0041FF93 /* FeedLoaderWithFallbackCompositeTests.swift */,
 				6041947427CA86DE0078DAF9 /* FeedImageDataLoaderWithFallbackCompositeTests.swift */,
 				600DDDBC2969572D00D984D8 /* FeedLoaderCacheDecoratorTests.swift */,
+				600FBACE2969676E00AF7D06 /* FeedImageDataLoaderCacheDecoratorTests.swift */,
 			);
 			path = EssentialAppTests;
 			sourceTree = "<group>";
@@ -282,6 +285,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				60BA15192967FCD400F9603B /* SharedTestHelpers.swift in Sources */,
+				600FBACF2969676E00AF7D06 /* FeedImageDataLoaderCacheDecoratorTests.swift in Sources */,
 				600DDDC129695B0C00D984D8 /* XCTestCase+FeedLoader.swift in Sources */,
 				600DDDBD2969572D00D984D8 /* FeedLoaderCacheDecoratorTests.swift in Sources */,
 				6041947527CA86DE0078DAF9 /* FeedImageDataLoaderWithFallbackCompositeTests.swift in Sources */,

--- a/EssentialApp/EssentialApp/FeedImageDataLoaderCacheDecorator.swift
+++ b/EssentialApp/EssentialApp/FeedImageDataLoaderCacheDecorator.swift
@@ -1,0 +1,28 @@
+//
+//  FeedImageDataLoaderCacheDecorator.swift
+//  EssentialApp
+//
+//  Created by Shibili Areekara on 07/01/23.
+//
+
+import Foundation
+import EssentialFeed
+
+public final class FeedImageDataLoaderCacheDecorator: FeedImageDataLoader {
+    private let decoratee: FeedImageDataLoader
+    private let cache: FeedImageDataCache
+    
+    public init(decoratee: FeedImageDataLoader, cache: FeedImageDataCache) {
+        self.decoratee = decoratee
+        self.cache = cache
+    }
+    
+    public func loadImageData(from url: URL, completion: @escaping (FeedImageDataLoader.Result) -> Void) -> FeedImageDataLoaderTask {
+        return decoratee.loadImageData(from: url) { [weak self] result in
+            completion(result.map({ data in
+                self?.cache.save(data, for: url) { _ in }
+                return data
+            }))
+        }
+    }
+}

--- a/EssentialApp/EssentialApp/FeedImageDataLoaderCacheDecorator.swift
+++ b/EssentialApp/EssentialApp/FeedImageDataLoaderCacheDecorator.swift
@@ -20,9 +20,15 @@ public final class FeedImageDataLoaderCacheDecorator: FeedImageDataLoader {
     public func loadImageData(from url: URL, completion: @escaping (FeedImageDataLoader.Result) -> Void) -> FeedImageDataLoaderTask {
         return decoratee.loadImageData(from: url) { [weak self] result in
             completion(result.map({ data in
-                self?.cache.save(data, for: url) { _ in }
+                self?.cache.saveIgnoringResult(data, for: url)
                 return data
             }))
         }
+    }
+}
+
+private extension FeedImageDataCache {
+    func saveIgnoringResult(_ data: Data, for url: URL) {
+        save(data, for: url) { _ in }
     }
 }

--- a/EssentialApp/EssentialApp/FeedLoaderCacheDecorator.swift
+++ b/EssentialApp/EssentialApp/FeedLoaderCacheDecorator.swift
@@ -1,0 +1,27 @@
+//
+//  FeedLoaderCacheDecorator.swift
+//  EssentialApp
+//
+//  Created by Shibili Areekara on 07/01/23.
+//
+
+import EssentialFeed
+
+public final class FeedLoaderCacheDecorator: FeedLoader  {
+    private let decoratee: FeedLoader
+    private let cache: FeedCache
+    
+    public init(decoratee: FeedLoader, cache: FeedCache) {
+        self.decoratee = decoratee
+        self.cache = cache
+    }
+    
+    public func load(completion: @escaping (FeedLoader.Result) -> Void) {
+        decoratee.load { [weak self] result in
+            completion(result.map{ feed in
+                self?.cache.save(feed) { _ in }
+                return feed
+            })
+        }
+    }
+}

--- a/EssentialApp/EssentialApp/FeedLoaderCacheDecorator.swift
+++ b/EssentialApp/EssentialApp/FeedLoaderCacheDecorator.swift
@@ -19,9 +19,15 @@ public final class FeedLoaderCacheDecorator: FeedLoader  {
     public func load(completion: @escaping (FeedLoader.Result) -> Void) {
         decoratee.load { [weak self] result in
             completion(result.map{ feed in
-                self?.cache.save(feed) { _ in }
+                self?.saveIgoringResult(feed)
                 return feed
             })
         }
+    }
+}
+
+private extension FeedLoaderCacheDecorator {
+    func saveIgoringResult(_ feed: [FeedImage]) {
+        cache.save(feed) { _ in }
     }
 }

--- a/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
@@ -8,12 +8,6 @@
 import XCTest
 import EssentialFeed
 
-protocol FeedImageDataCache {
-    typealias Result = Swift.Result<Void, Error>
-    
-    func save(_ data: Data, for url: URL, completion: @escaping (Result) -> Void)
-}
-
 final class FeedImageDataLoaderCacheDecorator: FeedImageDataLoader {
     private let decoratee: FeedImageDataLoader
     private let cache: FeedImageDataCache

--- a/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
@@ -65,8 +65,8 @@ final class FeedImageDataLoaderCacheDecoratorTests: XCTestCase {
     }
 
     //MARK: - Helpers
-    private func makeSUT(file: StaticString = #filePath, line: UInt = #line) -> (sut: FeedImageDataLoader, loader: LoaderSpy) {
-        let loader = LoaderSpy()
+    private func makeSUT(file: StaticString = #filePath, line: UInt = #line) -> (sut: FeedImageDataLoader, loader: FeedImageDataLoaderSpy) {
+        let loader = FeedImageDataLoaderSpy()
         let sut = FeedImageDataLoaderCacheDecorator(decoratee: loader)
         trackForMemoryLeaks(loader, file: file, line: line)
         trackForMemoryLeaks(sut, file: file, line: line)
@@ -94,35 +94,5 @@ final class FeedImageDataLoaderCacheDecoratorTests: XCTestCase {
         action()
         
         wait(for: [exp], timeout: 1.0)
-    }
-    
-    private final class LoaderSpy: FeedImageDataLoader {
-        private var messages = [(url: URL, completion: (FeedImageDataLoader.Result) -> Void)]()
-        
-        var loadedURLs: [URL] {
-            return messages.map { $0.url }
-        }
-        
-        private(set) var cancelledURLs = [URL]()
-        
-        private struct Task: FeedImageDataLoaderTask {
-            let callback: () -> Void
-            func cancel() { callback() }
-        }
-        
-        func loadImageData(from url: URL, completion: @escaping (FeedImageDataLoader.Result) -> Void) -> FeedImageDataLoaderTask {
-            messages.append((url, completion))
-            return Task { [weak self] in
-                self?.cancelledURLs.append(url)
-            }
-        }
-        
-        func complete(with error: Error, at index: Int = 0) {
-            messages[index].completion(.failure(error))
-        }
-        
-        func complete(with data: Data, at index: Int = 0) {
-            messages[index].completion(.success(data))
-        }
     }
 }

--- a/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
@@ -25,8 +25,10 @@ final class FeedImageDataLoaderCacheDecorator: FeedImageDataLoader {
     
     func loadImageData(from url: URL, completion: @escaping (FeedImageDataLoader.Result) -> Void) -> FeedImageDataLoaderTask {
         return decoratee.loadImageData(from: url) { [weak self] result in
-            self?.cache.save((try? result.get()) ?? Data(), for: url) { _ in }
-            completion(result)
+            completion(result.map({ data in
+                self?.cache.save(data, for: url) { _ in }
+                return data
+            }))
         }
     }
 }
@@ -85,6 +87,17 @@ final class FeedImageDataLoaderCacheDecoratorTests: XCTestCase, FeedImageDataLoa
         loader.complete(with: imageData)
         
         XCTAssertEqual(cache.messages, [.save(data: imageData, for: url)], "Expected to cache loaded image data on success")
+    }
+    
+    func test_loadImageData_doesNotCacheDataOnLoaderFailure() {
+        let cache = CacheSpy()
+        let url = anyURL()
+        let (sut, loader) = makeSUT(cache: cache)
+        
+        _ = sut.loadImageData(from: url) { _ in }
+        loader.complete(with: anyNSError())
+        
+        XCTAssertTrue(cache.messages.isEmpty, "Expected not to cache image data on load error")
     }
 
     //MARK: - Helpers

--- a/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
@@ -20,7 +20,7 @@ final class FeedImageDataLoaderCacheDecorator: FeedImageDataLoader {
     }
 }
 
-final class FeedImageDataLoaderCacheDecoratorTests: XCTestCase {
+final class FeedImageDataLoaderCacheDecoratorTests: XCTestCase, FeedImageDataLoaderTestCase {
     
     func test_init_doesNotImageData() {
         let (_, loader) = makeSUT()
@@ -71,28 +71,5 @@ final class FeedImageDataLoaderCacheDecoratorTests: XCTestCase {
         trackForMemoryLeaks(loader, file: file, line: line)
         trackForMemoryLeaks(sut, file: file, line: line)
         return (sut, loader)
-    }
-    
-    private func expect(_ sut: FeedImageDataLoader, toCompleteWith expectedResult: FeedImageDataLoader.Result, when action: () -> Void, file: StaticString = #filePath, line: UInt = #line) {
-        let exp = expectation(description: "Wait for load completion")
-        
-        _ = sut.loadImageData(from: anyURL()) { receivedResult in
-            switch (receivedResult, expectedResult) {
-            case let (.success(receivedFeed), .success(expectedFeed)):
-                XCTAssertEqual(receivedFeed, expectedFeed, file: file, line: line)
-                
-            case (.failure, .failure):
-                break
-                
-            default:
-                XCTFail("Expected \(expectedResult), got \(receivedResult) instead", file: file, line: line)
-            }
-            
-            exp.fulfill()
-        }
-        
-        action()
-        
-        wait(for: [exp], timeout: 1.0)
     }
 }

--- a/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
@@ -1,0 +1,128 @@
+//
+//  FeedImageDataLoaderCacheDecoratorTests.swift
+//  EssentialAppTests
+//
+//  Created by Shibili Areekara on 07/01/23.
+//
+
+import XCTest
+import EssentialFeed
+
+final class FeedImageDataLoaderCacheDecorator: FeedImageDataLoader {
+    private let decoratee: FeedImageDataLoader
+    
+    init(decoratee: FeedImageDataLoader) {
+        self.decoratee = decoratee
+    }
+    
+    func loadImageData(from url: URL, completion: @escaping (FeedImageDataLoader.Result) -> Void) -> FeedImageDataLoaderTask {
+        return decoratee.loadImageData(from: url, completion: completion)
+    }
+}
+
+final class FeedImageDataLoaderCacheDecoratorTests: XCTestCase {
+    
+    func test_init_doesNotImageData() {
+        let (_, loader) = makeSUT()
+        
+        XCTAssertTrue(loader.loadedURLs.isEmpty, "Expected no loaded URLs")
+    }
+    
+    func test_loadImageData_loadsFromLoader() {
+        let url = anyURL()
+        let (sut, loader) = makeSUT()
+        
+        _ = sut.loadImageData(from: url) { _ in }
+        
+        XCTAssertEqual(loader.loadedURLs, [url], "Expected to load URL from loader")
+    }
+    
+    func test_cancelLoadImageData_cancelsLoaderTask() {
+        let url = anyURL()
+        let (sut, loader) = makeSUT()
+        
+        let task = sut.loadImageData(from: url) { _ in }
+        task.cancel()
+        
+        XCTAssertEqual(loader.cancelledURLs, [url], "Expected to cancel URL loading from loader")
+    }
+    
+    func test_loadImageData_deliversDataOnLoaderSuccess() {
+        let imageData = anyData()
+        let (sut, loader) = makeSUT()
+        
+        expect(sut, toCompleteWith: .success(imageData), when: {
+            loader.complete(with: imageData)
+        })
+    }
+    
+    func test_loadImageData_deliversErrorOnLoaderFailure() {
+        let (sut, loader) = makeSUT()
+        
+        expect(sut, toCompleteWith: .failure(anyNSError()), when: {
+            loader.complete(with: anyNSError())
+        })
+    }
+
+    //MARK: - Helpers
+    private func makeSUT(file: StaticString = #filePath, line: UInt = #line) -> (sut: FeedImageDataLoader, loader: LoaderSpy) {
+        let loader = LoaderSpy()
+        let sut = FeedImageDataLoaderCacheDecorator(decoratee: loader)
+        trackForMemoryLeaks(loader, file: file, line: line)
+        trackForMemoryLeaks(sut, file: file, line: line)
+        return (sut, loader)
+    }
+    
+    private func expect(_ sut: FeedImageDataLoader, toCompleteWith expectedResult: FeedImageDataLoader.Result, when action: () -> Void, file: StaticString = #filePath, line: UInt = #line) {
+        let exp = expectation(description: "Wait for load completion")
+        
+        _ = sut.loadImageData(from: anyURL()) { receivedResult in
+            switch (receivedResult, expectedResult) {
+            case let (.success(receivedFeed), .success(expectedFeed)):
+                XCTAssertEqual(receivedFeed, expectedFeed, file: file, line: line)
+                
+            case (.failure, .failure):
+                break
+                
+            default:
+                XCTFail("Expected \(expectedResult), got \(receivedResult) instead", file: file, line: line)
+            }
+            
+            exp.fulfill()
+        }
+        
+        action()
+        
+        wait(for: [exp], timeout: 1.0)
+    }
+    
+    private final class LoaderSpy: FeedImageDataLoader {
+        private var messages = [(url: URL, completion: (FeedImageDataLoader.Result) -> Void)]()
+        
+        var loadedURLs: [URL] {
+            return messages.map { $0.url }
+        }
+        
+        private(set) var cancelledURLs = [URL]()
+        
+        private struct Task: FeedImageDataLoaderTask {
+            let callback: () -> Void
+            func cancel() { callback() }
+        }
+        
+        func loadImageData(from url: URL, completion: @escaping (FeedImageDataLoader.Result) -> Void) -> FeedImageDataLoaderTask {
+            messages.append((url, completion))
+            return Task { [weak self] in
+                self?.cancelledURLs.append(url)
+            }
+        }
+        
+        func complete(with error: Error, at index: Int = 0) {
+            messages[index].completion(.failure(error))
+        }
+        
+        func complete(with data: Data, at index: Int = 0) {
+            messages[index].completion(.success(data))
+        }
+    }
+}

--- a/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
@@ -7,25 +7,7 @@
 
 import XCTest
 import EssentialFeed
-
-final class FeedImageDataLoaderCacheDecorator: FeedImageDataLoader {
-    private let decoratee: FeedImageDataLoader
-    private let cache: FeedImageDataCache
-    
-    init(decoratee: FeedImageDataLoader, cache: FeedImageDataCache) {
-        self.decoratee = decoratee
-        self.cache = cache
-    }
-    
-    func loadImageData(from url: URL, completion: @escaping (FeedImageDataLoader.Result) -> Void) -> FeedImageDataLoaderTask {
-        return decoratee.loadImageData(from: url) { [weak self] result in
-            completion(result.map({ data in
-                self?.cache.save(data, for: url) { _ in }
-                return data
-            }))
-        }
-    }
-}
+import EssentialApp
 
 final class FeedImageDataLoaderCacheDecoratorTests: XCTestCase, FeedImageDataLoaderTestCase {
     

--- a/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
@@ -8,15 +8,26 @@
 import XCTest
 import EssentialFeed
 
+protocol FeedImageDataCache {
+    typealias Result = Swift.Result<Void, Error>
+    
+    func save(_ data: Data, for url: URL, completion: @escaping (Result) -> Void)
+}
+
 final class FeedImageDataLoaderCacheDecorator: FeedImageDataLoader {
     private let decoratee: FeedImageDataLoader
+    private let cache: FeedImageDataCache
     
-    init(decoratee: FeedImageDataLoader) {
+    init(decoratee: FeedImageDataLoader, cache: FeedImageDataCache) {
         self.decoratee = decoratee
+        self.cache = cache
     }
     
     func loadImageData(from url: URL, completion: @escaping (FeedImageDataLoader.Result) -> Void) -> FeedImageDataLoaderTask {
-        return decoratee.loadImageData(from: url, completion: completion)
+        return decoratee.loadImageData(from: url) { [weak self] result in
+            self?.cache.save((try? result.get()) ?? Data(), for: url) { _ in }
+            completion(result)
+        }
     }
 }
 
@@ -63,13 +74,38 @@ final class FeedImageDataLoaderCacheDecoratorTests: XCTestCase, FeedImageDataLoa
             loader.complete(with: anyNSError())
         })
     }
+    
+    func test_loadImageData_cachesLoadedDataOnLoaderSuccess() {
+        let cache = CacheSpy()
+        let url = anyURL()
+        let imageData = anyData()
+        let (sut, loader) = makeSUT(cache: cache)
+        
+        _ = sut.loadImageData(from: url) { _ in }
+        loader.complete(with: imageData)
+        
+        XCTAssertEqual(cache.messages, [.save(data: imageData, for: url)], "Expected to cache loaded image data on success")
+    }
 
     //MARK: - Helpers
-    private func makeSUT(file: StaticString = #filePath, line: UInt = #line) -> (sut: FeedImageDataLoader, loader: FeedImageDataLoaderSpy) {
+    private func makeSUT(cache: CacheSpy = .init(), file: StaticString = #filePath, line: UInt = #line) -> (sut: FeedImageDataLoader, loader: FeedImageDataLoaderSpy) {
         let loader = FeedImageDataLoaderSpy()
-        let sut = FeedImageDataLoaderCacheDecorator(decoratee: loader)
+        let sut = FeedImageDataLoaderCacheDecorator(decoratee: loader, cache: cache)
         trackForMemoryLeaks(loader, file: file, line: line)
         trackForMemoryLeaks(sut, file: file, line: line)
         return (sut, loader)
+    }
+    
+    private class CacheSpy: FeedImageDataCache {
+        private(set) var messages = [Message]()
+        
+        enum Message: Equatable {
+            case save(data: Data, for: URL)
+        }
+        
+        func save(_ data: Data, for url: URL, completion: @escaping (FeedImageDataCache.Result) -> Void) {
+            messages.append(.save(data: data, for: url))
+            completion(.success(()))
+        }
     }
 }

--- a/EssentialApp/EssentialAppTests/FeedImageDataLoaderWithFallbackCompositeTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedImageDataLoaderWithFallbackCompositeTests.swift
@@ -92,9 +92,9 @@ class FeedImageDataLoaderWithFallbackCompositeTests: XCTestCase {
     }
     
     //MARK: - Helpers
-    private func makeSUT(file: StaticString = #filePath, line: UInt = #line) -> (sut: FeedImageDataLoader, primary: LoaderSpy, fallback: LoaderSpy) {
-        let primaryLoader = LoaderSpy()
-        let fallbackLoader = LoaderSpy()
+    private func makeSUT(file: StaticString = #filePath, line: UInt = #line) -> (sut: FeedImageDataLoader, primary: FeedImageDataLoaderSpy, fallback: FeedImageDataLoaderSpy) {
+        let primaryLoader = FeedImageDataLoaderSpy()
+        let fallbackLoader = FeedImageDataLoaderSpy()
         let sut = FeedImageDataLoaderWithFallbackComposite(primary: primaryLoader, fallback: fallbackLoader)
         trackForMemoryLeaks(primaryLoader, file: file, line: line)
         trackForMemoryLeaks(fallbackLoader, file: file, line: line)
@@ -123,35 +123,5 @@ class FeedImageDataLoaderWithFallbackCompositeTests: XCTestCase {
         action()
         
         wait(for: [exp], timeout: 1.0)
-    }
-    
-    private final class LoaderSpy: FeedImageDataLoader {
-        private var messages = [(url: URL, completion: (FeedImageDataLoader.Result) -> Void)]()
-        
-        var loadedURLs: [URL] {
-            return messages.map { $0.url }
-        }
-        
-        private(set) var cancelledURLs = [URL]()
-        
-        private struct Task: FeedImageDataLoaderTask {
-            let callback: () -> Void
-            func cancel() { callback() }
-        }
-        
-        func loadImageData(from url: URL, completion: @escaping (FeedImageDataLoader.Result) -> Void) -> FeedImageDataLoaderTask {
-            messages.append((url, completion))
-            return Task { [weak self] in
-                self?.cancelledURLs.append(url)
-            }
-        }
-        
-        func complete(with error: Error, at index: Int = 0) {
-            messages[index].completion(.failure(error))
-        }
-        
-        func complete(with data: Data, at index: Int = 0) {
-            messages[index].completion(.success(data))
-        }
     }
 }

--- a/EssentialApp/EssentialAppTests/FeedImageDataLoaderWithFallbackCompositeTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedImageDataLoaderWithFallbackCompositeTests.swift
@@ -9,7 +9,7 @@ import XCTest
 import EssentialFeed
 import EssentialApp
 
-class FeedImageDataLoaderWithFallbackCompositeTests: XCTestCase {
+class FeedImageDataLoaderWithFallbackCompositeTests: XCTestCase, FeedImageDataLoaderTestCase {
     
     func test_init_doesNotLoadImageData() {
         let (_, primaryLoader, fallbackLoader) = makeSUT()
@@ -100,28 +100,5 @@ class FeedImageDataLoaderWithFallbackCompositeTests: XCTestCase {
         trackForMemoryLeaks(fallbackLoader, file: file, line: line)
         trackForMemoryLeaks(sut, file: file, line: line)
         return (sut, primaryLoader, fallbackLoader)
-    }
-    
-    private func expect(_ sut: FeedImageDataLoader, toCompleteWith expectedResult: FeedImageDataLoader.Result, when action: () -> Void, file: StaticString = #filePath, line: UInt = #line) {
-        let exp = expectation(description: "Wait for load completion")
-        
-        _ = sut.loadImageData(from: anyURL()) { receivedResult in
-            switch (receivedResult, expectedResult) {
-            case let (.success(receivedFeed), .success(expectedFeed)):
-                XCTAssertEqual(receivedFeed, expectedFeed, file: file, line: line)
-                
-            case (.failure, .failure):
-                break
-                
-            default:
-                XCTFail("Expected \(expectedResult), got \(receivedResult) instead", file: file, line: line)
-            }
-            
-            exp.fulfill()
-        }
-        
-        action()
-        
-        wait(for: [exp], timeout: 1.0)
     }
 }

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
@@ -8,15 +8,26 @@
 import XCTest
 import EssentialFeed
 
+protocol FeedCache {
+    typealias Result = Swift.Result<Void, Error>
+    
+    func save(_ feed: [FeedImage], completion: @escaping (Result) -> Void)
+}
+
 final class FeedLoaderCacheDecorator: FeedLoader  {
     private let decoratee: FeedLoader
+    private let cache: FeedCache
     
-    init(decoratee: FeedLoader) {
+    init(decoratee: FeedLoader, cache: FeedCache) {
         self.decoratee = decoratee
+        self.cache = cache
     }
     
     func load(completion: @escaping (FeedLoader.Result) -> Void) {
-        decoratee.load(completion: completion)
+        decoratee.load { [weak self] result in
+            self?.cache.save((try? result.get()) ?? []) { _ in }
+            completion(result)
+        }
     }
 }
 
@@ -35,14 +46,37 @@ class FeedLoaderCacheDecoratorTests: XCTestCase, FeedLoaderTestCase {
         expect(sut, toCompleteWith: .failure(anyNSError()))
     }
     
+    func test_load_cachesLoadedFeedOnLoaderSuccess() {
+        let cache = CacheSpy()
+        let feed = uniqueFeed()
+        let sut = makeSUT(loaderResult: .success(feed), cache: cache)
+        
+        sut.load { _ in }
+        
+        XCTAssertEqual(cache.messages, [.save(feed)], "Expected to cache loaded feed on success")
+    }
+    
     //MARK: - Helpers
     
-    private func makeSUT(loaderResult: FeedLoader.Result, file: StaticString = #filePath, line: UInt = #line) -> FeedLoaderCacheDecorator {
+    private func makeSUT(loaderResult: FeedLoader.Result, cache: CacheSpy = .init(), file: StaticString = #filePath, line: UInt = #line) -> FeedLoaderCacheDecorator {
         let loader = FeedLoaderStub(result: loaderResult)
-        let sut = FeedLoaderCacheDecorator(decoratee: loader)
+        let sut = FeedLoaderCacheDecorator(decoratee: loader, cache: cache)
         trackForMemoryLeaks(loader, file: file, line: line)
         trackForMemoryLeaks(sut, file: file, line: line)
         return sut
+    }
+    
+    private class CacheSpy: FeedCache {
+        private(set) var messages = [Message]()
+        
+        enum Message: Equatable {
+            case save([FeedImage])
+        }
+        
+        func save(_ feed: [FeedImage], completion: @escaping (FeedCache.Result) -> Void) {
+            messages.append(.save(feed))
+            completion(.success(()))
+        }
     }
 }
 

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
@@ -1,0 +1,80 @@
+//
+//  FeedLoaderCacheDecoratorTests.swift
+//  EssentialAppTests
+//
+//  Created by Shibili Areekara on 07/01/23.
+//
+
+import XCTest
+import EssentialFeed
+
+final class FeedLoaderCacheDecorator: FeedLoader  {
+    private let decoratee: FeedLoader
+    
+    init(decoratee: FeedLoader) {
+        self.decoratee = decoratee
+    }
+    
+    func load(completion: @escaping (FeedLoader.Result) -> Void) {
+        decoratee.load(completion: completion)
+    }
+}
+
+class FeedLoaderCacheDecoratorTests: XCTestCase {
+    
+    func test_load_deliversFeedOnLoaderSuccess() {
+        let feed = uniqueFeed()
+        let loader = LoaderStub(result: .success(feed))
+        let sut = FeedLoaderCacheDecorator(decoratee: loader)
+        
+        expect(sut, toCompleteWith: .success(feed))
+    }
+    
+    func test_load_deliversErrorOnLoaderFailure() {
+        let loader = LoaderStub(result: .failure(anyNSError()))
+        let sut = FeedLoaderCacheDecorator(decoratee: loader)
+        
+        expect(sut, toCompleteWith: .failure(anyNSError()))
+    }
+    
+    // MARK: - Helpers
+    
+    private func expect(_ sut: FeedLoader, toCompleteWith expectedResult: FeedLoader.Result, file: StaticString = #filePath, line: UInt = #line) {
+        let exp = expectation(description: "Wait for load completion")
+        
+        sut.load { receivedResult in
+            switch (receivedResult, expectedResult) {
+            case let (.success(receivedFeed), .success(expectedFeed)):
+                XCTAssertEqual(receivedFeed, expectedFeed, file: file, line: line)
+                
+            case (.failure, .failure):
+                break
+                
+            default:
+                XCTFail("Expected \(expectedResult), got \(receivedResult) instead", file: file, line: line)
+            }
+            
+            exp.fulfill()
+        }
+        
+        wait(for: [exp], timeout: 1.0)
+    }
+    
+    private func uniqueFeed() -> [FeedImage] {
+        return [FeedImage(id: UUID(), description: "any", location: "any", url: anyURL())]
+    }
+        
+    private class LoaderStub: FeedLoader {
+        private let result: FeedLoader.Result
+        
+        init(result: FeedLoader.Result) {
+            self.result = result
+        }
+        
+        func load(completion: @escaping (FeedLoader.Result) -> Void) {
+            completion(result)
+        }
+    }
+    
+}
+

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
@@ -24,14 +24,14 @@ class FeedLoaderCacheDecoratorTests: XCTestCase {
     
     func test_load_deliversFeedOnLoaderSuccess() {
         let feed = uniqueFeed()
-        let loader = LoaderStub(result: .success(feed))
+        let loader = FeedLoaderStub(result: .success(feed))
         let sut = FeedLoaderCacheDecorator(decoratee: loader)
         
         expect(sut, toCompleteWith: .success(feed))
     }
     
     func test_load_deliversErrorOnLoaderFailure() {
-        let loader = LoaderStub(result: .failure(anyNSError()))
+        let loader = FeedLoaderStub(result: .failure(anyNSError()))
         let sut = FeedLoaderCacheDecorator(decoratee: loader)
         
         expect(sut, toCompleteWith: .failure(anyNSError()))
@@ -62,18 +62,6 @@ class FeedLoaderCacheDecoratorTests: XCTestCase {
     
     private func uniqueFeed() -> [FeedImage] {
         return [FeedImage(id: UUID(), description: "any", location: "any", url: anyURL())]
-    }
-        
-    private class LoaderStub: FeedLoader {
-        private let result: FeedLoader.Result
-        
-        init(result: FeedLoader.Result) {
-            self.result = result
-        }
-        
-        func load(completion: @escaping (FeedLoader.Result) -> Void) {
-            completion(result)
-        }
     }
     
 }

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
@@ -25,10 +25,10 @@ final class FeedLoaderCacheDecorator: FeedLoader  {
     
     func load(completion: @escaping (FeedLoader.Result) -> Void) {
         decoratee.load { [weak self] result in
-            if let feed = try? result.get() {
+            completion(result.map{ feed in
                 self?.cache.save(feed) { _ in }
-            }
-            completion(result)
+                return feed
+            })
         }
     }
 }

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
@@ -7,25 +7,7 @@
 
 import XCTest
 import EssentialFeed
-
-final class FeedLoaderCacheDecorator: FeedLoader  {
-    private let decoratee: FeedLoader
-    private let cache: FeedCache
-    
-    init(decoratee: FeedLoader, cache: FeedCache) {
-        self.decoratee = decoratee
-        self.cache = cache
-    }
-    
-    func load(completion: @escaping (FeedLoader.Result) -> Void) {
-        decoratee.load { [weak self] result in
-            completion(result.map{ feed in
-                self?.cache.save(feed) { _ in }
-                return feed
-            })
-        }
-    }
-}
+import EssentialApp
 
 class FeedLoaderCacheDecoratorTests: XCTestCase, FeedLoaderTestCase {
     

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
@@ -20,7 +20,7 @@ final class FeedLoaderCacheDecorator: FeedLoader  {
     }
 }
 
-class FeedLoaderCacheDecoratorTests: XCTestCase {
+class FeedLoaderCacheDecoratorTests: XCTestCase, FeedLoaderTestCase {
     
     func test_load_deliversFeedOnLoaderSuccess() {
         let feed = uniqueFeed()
@@ -35,29 +35,6 @@ class FeedLoaderCacheDecoratorTests: XCTestCase {
         let sut = FeedLoaderCacheDecorator(decoratee: loader)
         
         expect(sut, toCompleteWith: .failure(anyNSError()))
-    }
-    
-    // MARK: - Helpers
-    
-    private func expect(_ sut: FeedLoader, toCompleteWith expectedResult: FeedLoader.Result, file: StaticString = #filePath, line: UInt = #line) {
-        let exp = expectation(description: "Wait for load completion")
-        
-        sut.load { receivedResult in
-            switch (receivedResult, expectedResult) {
-            case let (.success(receivedFeed), .success(expectedFeed)):
-                XCTAssertEqual(receivedFeed, expectedFeed, file: file, line: line)
-                
-            case (.failure, .failure):
-                break
-                
-            default:
-                XCTFail("Expected \(expectedResult), got \(receivedResult) instead", file: file, line: line)
-            }
-            
-            exp.fulfill()
-        }
-        
-        wait(for: [exp], timeout: 1.0)
     }
 }
 

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
@@ -59,10 +59,5 @@ class FeedLoaderCacheDecoratorTests: XCTestCase {
         
         wait(for: [exp], timeout: 1.0)
     }
-    
-    private func uniqueFeed() -> [FeedImage] {
-        return [FeedImage(id: UUID(), description: "any", location: "any", url: anyURL())]
-    }
-    
 }
 

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
@@ -24,17 +24,25 @@ class FeedLoaderCacheDecoratorTests: XCTestCase, FeedLoaderTestCase {
     
     func test_load_deliversFeedOnLoaderSuccess() {
         let feed = uniqueFeed()
-        let loader = FeedLoaderStub(result: .success(feed))
-        let sut = FeedLoaderCacheDecorator(decoratee: loader)
+        let sut = makeSUT(loaderResult: .success(feed))
         
         expect(sut, toCompleteWith: .success(feed))
     }
     
     func test_load_deliversErrorOnLoaderFailure() {
-        let loader = FeedLoaderStub(result: .failure(anyNSError()))
-        let sut = FeedLoaderCacheDecorator(decoratee: loader)
+        let sut = makeSUT(loaderResult: .failure(anyNSError()))
         
         expect(sut, toCompleteWith: .failure(anyNSError()))
+    }
+    
+    //MARK: - Helpers
+    
+    private func makeSUT(loaderResult: FeedLoader.Result, file: StaticString = #filePath, line: UInt = #line) -> FeedLoaderCacheDecorator {
+        let loader = FeedLoaderStub(result: loaderResult)
+        let sut = FeedLoaderCacheDecorator(decoratee: loader)
+        trackForMemoryLeaks(loader, file: file, line: line)
+        trackForMemoryLeaks(sut, file: file, line: line)
+        return sut
     }
 }
 

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
@@ -8,12 +8,6 @@
 import XCTest
 import EssentialFeed
 
-protocol FeedCache {
-    typealias Result = Swift.Result<Void, Error>
-    
-    func save(_ feed: [FeedImage], completion: @escaping (Result) -> Void)
-}
-
 final class FeedLoaderCacheDecorator: FeedLoader  {
     private let decoratee: FeedLoader
     private let cache: FeedCache

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
@@ -25,7 +25,9 @@ final class FeedLoaderCacheDecorator: FeedLoader  {
     
     func load(completion: @escaping (FeedLoader.Result) -> Void) {
         decoratee.load { [weak self] result in
-            self?.cache.save((try? result.get()) ?? []) { _ in }
+            if let feed = try? result.get() {
+                self?.cache.save(feed) { _ in }
+            }
             completion(result)
         }
     }
@@ -56,9 +58,18 @@ class FeedLoaderCacheDecoratorTests: XCTestCase, FeedLoaderTestCase {
         XCTAssertEqual(cache.messages, [.save(feed)], "Expected to cache loaded feed on success")
     }
     
+    func test_load_doesNotCacheOnLoaderFailure() {
+        let cache = CacheSpy()
+        let sut = makeSUT(loaderResult: .failure(anyNSError()), cache: cache)
+        
+        sut.load { _ in }
+        
+        XCTAssertTrue(cache.messages.isEmpty, "Expected not to cache on load error")
+    }
+    
     //MARK: - Helpers
     
-    private func makeSUT(loaderResult: FeedLoader.Result, cache: CacheSpy = .init(), file: StaticString = #filePath, line: UInt = #line) -> FeedLoaderCacheDecorator {
+    private func makeSUT(loaderResult: FeedLoader.Result, cache: CacheSpy = .init(), file: StaticString = #filePath, line: UInt = #line) -> FeedLoader {
         let loader = FeedLoaderStub(result: loaderResult)
         let sut = FeedLoaderCacheDecorator(decoratee: loader, cache: cache)
         trackForMemoryLeaks(loader, file: file, line: line)

--- a/EssentialApp/EssentialAppTests/FeedLoaderWithFallbackCompositeTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderWithFallbackCompositeTests.swift
@@ -64,8 +64,4 @@ class FeedLoaderWithFallbackCompositeTests: XCTestCase {
         
         wait(for: [exp], timeout: 1.0)
     }
-    
-    private func uniqueFeed() -> [FeedImage] {
-        return [FeedImage(id: UUID(), description: "any", location: "any", url: anyURL())]
-    }
 }

--- a/EssentialApp/EssentialAppTests/FeedLoaderWithFallbackCompositeTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderWithFallbackCompositeTests.swift
@@ -9,7 +9,7 @@ import XCTest
 import EssentialFeed
 import EssentialApp
 
-class FeedLoaderWithFallbackCompositeTests: XCTestCase {
+class FeedLoaderWithFallbackCompositeTests: XCTestCase, FeedLoaderTestCase {
     
     func test_load_deliversPrimaryFeedOnPrimaryLoaderSuccess() {
         let primaryFeed = uniqueFeed()
@@ -42,26 +42,5 @@ class FeedLoaderWithFallbackCompositeTests: XCTestCase {
         trackForMemoryLeaks(fallbackLoader, file: file, line: line)
         trackForMemoryLeaks(sut, file: file, line: line)
         return sut
-    }
-    
-    private func expect(_ sut: FeedLoader, toCompleteWith expectedResult: FeedLoader.Result, file: StaticString = #filePath, line: UInt = #line) {
-        let exp = expectation(description: "Wait for load completion")
-        
-        sut.load { receivedResult in
-            switch (receivedResult, expectedResult) {
-            case let (.success(receivedFeed), .success(expectedFeed)):
-                XCTAssertEqual(receivedFeed, expectedFeed, file: file, line: line)
-                
-            case (.failure, .failure):
-                break
-                
-            default:
-                XCTFail("Expected \(expectedResult), got \(receivedResult) instead", file: file, line: line)
-            }
-            
-            exp.fulfill()
-        }
-        
-        wait(for: [exp], timeout: 1.0)
     }
 }

--- a/EssentialApp/EssentialAppTests/FeedLoaderWithFallbackCompositeTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderWithFallbackCompositeTests.swift
@@ -35,8 +35,8 @@ class FeedLoaderWithFallbackCompositeTests: XCTestCase {
     //MARK: - Helpers
     
     private func makeSUT(primaryResult: FeedLoader.Result, fallbackResult: FeedLoader.Result, file: StaticString = #filePath, line: UInt = #line) -> FeedLoaderWithFallbackComposite {
-        let primaryLoader = LoaderStub(result: primaryResult)
-        let fallbackLoader = LoaderStub(result: fallbackResult)
+        let primaryLoader = FeedLoaderStub(result: primaryResult)
+        let fallbackLoader = FeedLoaderStub(result: fallbackResult)
         let sut = FeedLoaderWithFallbackComposite(primary: primaryLoader, fallback: fallbackLoader)
         trackForMemoryLeaks(primaryLoader, file: file, line: line)
         trackForMemoryLeaks(fallbackLoader, file: file, line: line)
@@ -67,17 +67,5 @@ class FeedLoaderWithFallbackCompositeTests: XCTestCase {
     
     private func uniqueFeed() -> [FeedImage] {
         return [FeedImage(id: UUID(), description: "any", location: "any", url: anyURL())]
-    }
-        
-    private class LoaderStub: FeedLoader {
-        private let result: FeedLoader.Result
-        
-        init(result: FeedLoader.Result) {
-            self.result = result
-        }
-        
-        func load(completion: @escaping (FeedLoader.Result) -> Void) {
-            completion(result)
-        }
     }
 }

--- a/EssentialApp/EssentialAppTests/Helpers/FeedImageDataLoaderSpy.swift
+++ b/EssentialApp/EssentialAppTests/Helpers/FeedImageDataLoaderSpy.swift
@@ -1,0 +1,39 @@
+//
+//  FeedImageDataLoaderSpy.swift
+//  EssentialAppTests
+//
+//  Created by Shibili Areekara on 07/01/23.
+//
+
+import Foundation
+import EssentialFeed
+
+final class FeedImageDataLoaderSpy: FeedImageDataLoader {
+    private var messages = [(url: URL, completion: (FeedImageDataLoader.Result) -> Void)]()
+    
+    var loadedURLs: [URL] {
+        return messages.map { $0.url }
+    }
+    
+    private(set) var cancelledURLs = [URL]()
+    
+    private struct Task: FeedImageDataLoaderTask {
+        let callback: () -> Void
+        func cancel() { callback() }
+    }
+    
+    func loadImageData(from url: URL, completion: @escaping (FeedImageDataLoader.Result) -> Void) -> FeedImageDataLoaderTask {
+        messages.append((url, completion))
+        return Task { [weak self] in
+            self?.cancelledURLs.append(url)
+        }
+    }
+    
+    func complete(with error: Error, at index: Int = 0) {
+        messages[index].completion(.failure(error))
+    }
+    
+    func complete(with data: Data, at index: Int = 0) {
+        messages[index].completion(.success(data))
+    }
+}

--- a/EssentialApp/EssentialAppTests/Helpers/FeedLoaderStub.swift
+++ b/EssentialApp/EssentialAppTests/Helpers/FeedLoaderStub.swift
@@ -1,0 +1,20 @@
+//
+//  FeedLoaderStub.swift
+//  EssentialAppTests
+//
+//  Created by Shibili Areekara on 07/01/23.
+//
+
+import EssentialFeed
+
+class FeedLoaderStub: FeedLoader {
+    private let result: FeedLoader.Result
+    
+    init(result: FeedLoader.Result) {
+        self.result = result
+    }
+    
+    func load(completion: @escaping (FeedLoader.Result) -> Void) {
+        completion(result)
+    }
+}

--- a/EssentialApp/EssentialAppTests/Helpers/SharedTestHelpers.swift
+++ b/EssentialApp/EssentialAppTests/Helpers/SharedTestHelpers.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import EssentialFeed
 
 func anyData() -> Data {
     return Data("any data".utf8)
@@ -17,4 +18,8 @@ func anyURL() -> URL {
 
 func anyNSError() -> NSError {
     NSError(domain: "any error", code: 0)
+}
+
+func uniqueFeed() -> [FeedImage] {
+    return [FeedImage(id: UUID(), description: "any", location: "any", url: anyURL())]
 }

--- a/EssentialApp/EssentialAppTests/Helpers/XCTestCase+FeedImageDataLoader.swift
+++ b/EssentialApp/EssentialAppTests/Helpers/XCTestCase+FeedImageDataLoader.swift
@@ -1,0 +1,36 @@
+//
+//  XCTestCase+FeedImageDataLoader.swift
+//  EssentialAppTests
+//
+//  Created by Shibili Areekara on 07/01/23.
+//
+
+import XCTest
+import EssentialFeed
+
+protocol FeedImageDataLoaderTestCase: XCTestCase {}
+
+extension FeedImageDataLoaderTestCase {
+    func expect(_ sut: FeedImageDataLoader, toCompleteWith expectedResult: FeedImageDataLoader.Result, when action: () -> Void, file: StaticString = #filePath, line: UInt = #line) {
+        let exp = expectation(description: "Wait for load completion")
+        
+        _ = sut.loadImageData(from: anyURL()) { receivedResult in
+            switch (receivedResult, expectedResult) {
+            case let (.success(receivedFeed), .success(expectedFeed)):
+                XCTAssertEqual(receivedFeed, expectedFeed, file: file, line: line)
+                
+            case (.failure, .failure):
+                break
+                
+            default:
+                XCTFail("Expected \(expectedResult), got \(receivedResult) instead", file: file, line: line)
+            }
+            
+            exp.fulfill()
+        }
+        
+        action()
+        
+        wait(for: [exp], timeout: 1.0)
+    }
+}

--- a/EssentialApp/EssentialAppTests/Helpers/XCTestCase+FeedLoader.swift
+++ b/EssentialApp/EssentialAppTests/Helpers/XCTestCase+FeedLoader.swift
@@ -1,0 +1,35 @@
+//
+//  XCTestCase+FeedLoader.swift
+//  EssentialAppTests
+//
+//  Created by Shibili Areekara on 07/01/23.
+//
+
+import XCTest
+import EssentialFeed
+
+protocol FeedLoaderTestCase: XCTestCase {}
+
+extension FeedLoaderTestCase {
+    func expect(_ sut: FeedLoader, toCompleteWith expectedResult: FeedLoader.Result, file: StaticString = #filePath, line: UInt = #line) {
+        let exp = expectation(description: "Wait for load completion")
+        
+        sut.load { receivedResult in
+            switch (receivedResult, expectedResult) {
+            case let (.success(receivedFeed), .success(expectedFeed)):
+                XCTAssertEqual(receivedFeed, expectedFeed, file: file, line: line)
+                
+            case (.failure, .failure):
+                break
+                
+            default:
+                XCTFail("Expected \(expectedResult), got \(receivedResult) instead", file: file, line: line)
+            }
+            
+            exp.fulfill()
+        }
+        
+        wait(for: [exp], timeout: 1.0)
+    }
+}
+

--- a/EssentialFeed/EssentialFeed.xcodeproj/project.pbxproj
+++ b/EssentialFeed/EssentialFeed.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		600FBACB2969656C00AF7D06 /* FeedCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600FBACA2969656C00AF7D06 /* FeedCache.swift */; };
+		600FBAD52969807B00AF7D06 /* FeedImageDataCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600FBAD42969807B00AF7D06 /* FeedImageDataCache.swift */; };
 		6024285C27ABEF68000F6D71 /* LoadFeedFromCacheUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6024285B27ABEF68000F6D71 /* LoadFeedFromCacheUseCaseTests.swift */; };
 		6024285F27ABF0C8000F6D71 /* FeedStoreSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6024285E27ABF0C8000F6D71 /* FeedStoreSpy.swift */; };
 		609D50F1279EA99100C7288E /* XCTestCase+MemoryLeakTracking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 609D50F0279EA99100C7288E /* XCTestCase+MemoryLeakTracking.swift */; };
@@ -158,6 +159,7 @@
 
 /* Begin PBXFileReference section */
 		600FBACA2969656C00AF7D06 /* FeedCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedCache.swift; sourceTree = "<group>"; };
+		600FBAD42969807B00AF7D06 /* FeedImageDataCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataCache.swift; sourceTree = "<group>"; };
 		6024285B27ABEF68000F6D71 /* LoadFeedFromCacheUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadFeedFromCacheUseCaseTests.swift; sourceTree = "<group>"; };
 		6024285E27ABF0C8000F6D71 /* FeedStoreSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedStoreSpy.swift; sourceTree = "<group>"; };
 		609D50F0279EA99100C7288E /* XCTestCase+MemoryLeakTracking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+MemoryLeakTracking.swift"; sourceTree = "<group>"; };
@@ -451,6 +453,7 @@
 				60ACFEBE2799A9AF00BEA2CA /* FeedLoader.swift */,
 				600FBACA2969656C00AF7D06 /* FeedCache.swift */,
 				60B4BC1E27BACD0200907878 /* FeedImageDataLoader.swift */,
+				600FBAD42969807B00AF7D06 /* FeedImageDataCache.swift */,
 			);
 			path = FeedFeature;
 			sourceTree = "<group>";
@@ -893,6 +896,7 @@
 				60DEDAFA27C21A2F00B541DF /* FeedViewModel.swift in Sources */,
 				60EA879A27AAF111001E9D38 /* LocalFeedLoader.swift in Sources */,
 				60B4CB95279D1BE000853D26 /* HTTPClient.swift in Sources */,
+				600FBAD52969807B00AF7D06 /* FeedImageDataCache.swift in Sources */,
 				60DEDB1227C4DBB400B541DF /* FeedImageDataStore.swift in Sources */,
 				60ACFEBD2799A82600BEA2CA /* FeedImage.swift in Sources */,
 				60DEDAF327C2184300B541DF /* FeedPresenter.swift in Sources */,

--- a/EssentialFeed/EssentialFeed.xcodeproj/project.pbxproj
+++ b/EssentialFeed/EssentialFeed.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		600FBACB2969656C00AF7D06 /* FeedCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600FBACA2969656C00AF7D06 /* FeedCache.swift */; };
 		6024285C27ABEF68000F6D71 /* LoadFeedFromCacheUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6024285B27ABEF68000F6D71 /* LoadFeedFromCacheUseCaseTests.swift */; };
 		6024285F27ABF0C8000F6D71 /* FeedStoreSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6024285E27ABF0C8000F6D71 /* FeedStoreSpy.swift */; };
 		609D50F1279EA99100C7288E /* XCTestCase+MemoryLeakTracking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 609D50F0279EA99100C7288E /* XCTestCase+MemoryLeakTracking.swift */; };
@@ -156,6 +157,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		600FBACA2969656C00AF7D06 /* FeedCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedCache.swift; sourceTree = "<group>"; };
 		6024285B27ABEF68000F6D71 /* LoadFeedFromCacheUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadFeedFromCacheUseCaseTests.swift; sourceTree = "<group>"; };
 		6024285E27ABF0C8000F6D71 /* FeedStoreSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedStoreSpy.swift; sourceTree = "<group>"; };
 		609D50F0279EA99100C7288E /* XCTestCase+MemoryLeakTracking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+MemoryLeakTracking.swift"; sourceTree = "<group>"; };
@@ -447,6 +449,7 @@
 			children = (
 				60ACFEBC2799A82600BEA2CA /* FeedImage.swift */,
 				60ACFEBE2799A9AF00BEA2CA /* FeedLoader.swift */,
+				600FBACA2969656C00AF7D06 /* FeedCache.swift */,
 				60B4BC1E27BACD0200907878 /* FeedImageDataLoader.swift */,
 			);
 			path = FeedFeature;
@@ -901,6 +904,7 @@
 				60DEDAF827C21A0100B541DF /* FeedLoadingViewModel.swift in Sources */,
 				60DEDB1427C4DBF500B541DF /* LocalFeedImageDataLoader.swift in Sources */,
 				60DEDAFF27C236B800B541DF /* FeedImagePresenter.swift in Sources */,
+				600FBACB2969656C00AF7D06 /* FeedCache.swift in Sources */,
 				60A040A427B5057200801A7A /* ManagedFeedImage.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/EssentialFeed/EssentialFeed/Feed Cache/LocalFeedImageDataLoader.swift
+++ b/EssentialFeed/EssentialFeed/Feed Cache/LocalFeedImageDataLoader.swift
@@ -15,8 +15,8 @@ public final class LocalFeedImageDataLoader {
     }
 }
 
-extension LocalFeedImageDataLoader {
-    public typealias SaveResult = Result<Void, Swift.Error>
+extension LocalFeedImageDataLoader: FeedImageDataCache {
+    public typealias SaveResult = FeedImageDataCache.Result
     
     public enum SaveError: Swift.Error {
         case failed

--- a/EssentialFeed/EssentialFeed/Feed Cache/LocalFeedLoader.swift
+++ b/EssentialFeed/EssentialFeed/Feed Cache/LocalFeedLoader.swift
@@ -17,8 +17,8 @@ public final class LocalFeedLoader {
     }
 }
 
-extension LocalFeedLoader {
-    public typealias SaveResult = Result<Void, Error>
+extension LocalFeedLoader: FeedCache {
+    public typealias SaveResult = FeedCache.Result
     
     public func save(_ feed: [FeedImage], completion: @escaping (SaveResult) -> Void) {
         store.deleteCachedFeed { [weak self] deletionResult in

--- a/EssentialFeed/EssentialFeed/FeedFeature/FeedCache.swift
+++ b/EssentialFeed/EssentialFeed/FeedFeature/FeedCache.swift
@@ -1,0 +1,14 @@
+//
+//  FeedCache.swift
+//  EssentialFeed
+//
+//  Created by Shibili Areekara on 07/01/23.
+//
+
+import Foundation
+
+public protocol FeedCache {
+    typealias Result = Swift.Result<Void, Error>
+    
+    func save(_ feed: [FeedImage], completion: @escaping (Result) -> Void)
+}

--- a/EssentialFeed/EssentialFeed/FeedFeature/FeedImageDataCache.swift
+++ b/EssentialFeed/EssentialFeed/FeedFeature/FeedImageDataCache.swift
@@ -1,0 +1,14 @@
+//
+//  FeedImageDataCache.swift
+//  EssentialFeed
+//
+//  Created by Shibili Areekara on 07/01/23.
+//
+
+import Foundation
+
+public protocol FeedImageDataCache {
+    typealias Result = Swift.Result<Void, Error>
+    
+    func save(_ data: Data, for url: URL, completion: @escaping (Result) -> Void)
+}


### PR DESCRIPTION
Added `[*]LoaderCacheDecorators` responsible for decorating (intercepting) `load` operations and injecting the `save` side-effect on successful load results.

We can now use the decorators to compose the `RemoteFeedLoader.load` with the `LocalFeedLoader.save` operations in a simple, clean, extendable, modular, and testable way.