### PR TITLE
Fix potential crash on `didEndDisplayingCell`

### DIFF
--- a/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
+++ b/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		60E3DEFD27C6933E00376750 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 60E3DEFB27C6933E00376750 /* Main.storyboard */; };
 		60E3DEFF27C6934000376750 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 60E3DEFE27C6934000376750 /* Assets.xcassets */; };
 		60E3DF0227C6934000376750 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 60E3DF0027C6934000376750 /* LaunchScreen.storyboard */; };
+		60E7FA9029B6028E001A1066 /* UIView+TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60E7FA8F29B6028E001A1066 /* UIView+TestHelpers.swift */; };
 		60EE2B5E296AE82200C247D5 /* SceneDelegateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60EE2B5D296AE82200C247D5 /* SceneDelegateTests.swift */; };
 		60EE2B71296AED5200C247D5 /* FeedImageDataLoaderPresentationAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60EE2B6B296AED5000C247D5 /* FeedImageDataLoaderPresentationAdapter.swift */; };
 		60EE2B72296AED5200C247D5 /* FeedViewAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60EE2B6C296AED5100C247D5 /* FeedViewAdapter.swift */; };
@@ -104,6 +105,7 @@
 		60E3DF0127C6934000376750 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		60E3DF0327C6934000376750 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		60E3DF0827C6934000376750 /* EssentialAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = EssentialAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		60E7FA8F29B6028E001A1066 /* UIView+TestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+TestHelpers.swift"; sourceTree = "<group>"; };
 		60EE2B5D296AE82200C247D5 /* SceneDelegateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegateTests.swift; sourceTree = "<group>"; };
 		60EE2B6B296AED5000C247D5 /* FeedImageDataLoaderPresentationAdapter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoaderPresentationAdapter.swift; sourceTree = "<group>"; };
 		60EE2B6C296AED5100C247D5 /* FeedViewAdapter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FeedViewAdapter.swift; sourceTree = "<group>"; };
@@ -175,6 +177,7 @@
 				60EE2B7A296AEDD600C247D5 /* UIButton+TestHelpers.swift */,
 				60EE2B77296AEDD500C247D5 /* UIControl+TestHelpers.swift */,
 				60EE2B7B296AEDD600C247D5 /* UIRefreshControl+TestHelpers.swift */,
+				60E7FA8F29B6028E001A1066 /* UIView+TestHelpers.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -378,6 +381,7 @@
 				6001982B27C9266F0041FF93 /* FeedLoaderWithFallbackCompositeTests.swift in Sources */,
 				60EE2B8E296C945E00C247D5 /* HTTPClientStub.swift in Sources */,
 				60EE2B82296AEDD800C247D5 /* UIRefreshControl+TestHelpers.swift in Sources */,
+				60E7FA9029B6028E001A1066 /* UIView+TestHelpers.swift in Sources */,
 				600DDDBF29695A0100D984D8 /* FeedLoaderStub.swift in Sources */,
 				60EE2B87296AEDD800C247D5 /* UIControl+TestHelpers.swift in Sources */,
 				60EE2B8C296AF12800C247D5 /* FeedAcceptanceTests.swift in Sources */,

--- a/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
+++ b/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
@@ -42,7 +42,7 @@
 		60EE2B81296AEDD800C247D5 /* FeedImageCell+TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60EE2B78296AEDD500C247D5 /* FeedImageCell+TestHelpers.swift */; };
 		60EE2B82296AEDD800C247D5 /* UIRefreshControl+TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60EE2B7B296AEDD600C247D5 /* UIRefreshControl+TestHelpers.swift */; };
 		60EE2B83296AEDD800C247D5 /* FeedViewControllerTests+LoaderSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60EE2B7D296AEDD600C247D5 /* FeedViewControllerTests+LoaderSpy.swift */; };
-		60EE2B84296AEDD800C247D5 /* FeedViewControllerTests+Assertions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60EE2B7E296AEDD700C247D5 /* FeedViewControllerTests+Assertions.swift */; };
+		60EE2B84296AEDD800C247D5 /* FeedUIIntegrationTests+Assertions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60EE2B7E296AEDD700C247D5 /* FeedUIIntegrationTests+Assertions.swift */; };
 		60EE2B85296AEDD800C247D5 /* UIImage+TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60EE2B7C296AEDD600C247D5 /* UIImage+TestHelpers.swift */; };
 		60EE2B86296AEDD800C247D5 /* UIButton+TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60EE2B7A296AEDD600C247D5 /* UIButton+TestHelpers.swift */; };
 		60EE2B87296AEDD800C247D5 /* UIControl+TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60EE2B77296AEDD500C247D5 /* UIControl+TestHelpers.swift */; };
@@ -118,7 +118,7 @@
 		60EE2B7B296AEDD600C247D5 /* UIRefreshControl+TestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIRefreshControl+TestHelpers.swift"; sourceTree = "<group>"; };
 		60EE2B7C296AEDD600C247D5 /* UIImage+TestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+TestHelpers.swift"; sourceTree = "<group>"; };
 		60EE2B7D296AEDD600C247D5 /* FeedViewControllerTests+LoaderSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FeedViewControllerTests+LoaderSpy.swift"; sourceTree = "<group>"; };
-		60EE2B7E296AEDD700C247D5 /* FeedViewControllerTests+Assertions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FeedViewControllerTests+Assertions.swift"; sourceTree = "<group>"; };
+		60EE2B7E296AEDD700C247D5 /* FeedUIIntegrationTests+Assertions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FeedUIIntegrationTests+Assertions.swift"; sourceTree = "<group>"; };
 		60EE2B7F296AEDD700C247D5 /* FeedViewController+TestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FeedViewController+TestHelpers.swift"; sourceTree = "<group>"; };
 		60EE2B89296AEDEC00C247D5 /* FeedUIIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedUIIntegrationTests.swift; sourceTree = "<group>"; };
 		60EE2B8B296AF12800C247D5 /* FeedAcceptanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedAcceptanceTests.swift; sourceTree = "<group>"; };
@@ -168,7 +168,7 @@
 				600FBAD229696D1100AF7D06 /* XCTestCase+FeedImageDataLoader.swift */,
 				60EE2B7F296AEDD700C247D5 /* FeedViewController+TestHelpers.swift */,
 				60EE2B7D296AEDD600C247D5 /* FeedViewControllerTests+LoaderSpy.swift */,
-				60EE2B7E296AEDD700C247D5 /* FeedViewControllerTests+Assertions.swift */,
+				60EE2B7E296AEDD700C247D5 /* FeedUIIntegrationTests+Assertions.swift */,
 				60EE2B79296AEDD500C247D5 /* FeedUIIntegrationTests+Localization.swift */,
 				60EE2B78296AEDD500C247D5 /* FeedImageCell+TestHelpers.swift */,
 				60EE2B7C296AEDD600C247D5 /* UIImage+TestHelpers.swift */,
@@ -383,7 +383,7 @@
 				60EE2B8C296AF12800C247D5 /* FeedAcceptanceTests.swift in Sources */,
 				60BA15172967FC2600F9603B /* XCTestCase+MemoryLeakTracking.swift in Sources */,
 				60EE2B8A296AEDEC00C247D5 /* FeedUIIntegrationTests.swift in Sources */,
-				60EE2B84296AEDD800C247D5 /* FeedViewControllerTests+Assertions.swift in Sources */,
+				60EE2B84296AEDD800C247D5 /* FeedUIIntegrationTests+Assertions.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/EssentialApp/EssentialAppTests/FeedUIIntegrationTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedUIIntegrationTests.swift
@@ -56,16 +56,30 @@ class FeedUIIntegrationTests: XCTestCase {
         let image2 = makeImage(description: "another description", location: nil)
         let image3 = makeImage(description: nil, location: nil)
         let (sut, loader) = makeSUT()
-        
+
         sut.loadViewIfNeeded()
         assertThat(sut, isRendering: [])
-        
+
         loader.completeFeedLoading(with: [image0], at: 0)
         assertThat(sut, isRendering: [image0])
-        
+
         sut.simulateUserInitiatedFeedReload()
         loader.completeFeedLoading(with: [image0, image1, image2, image3], at: 1)
         assertThat(sut, isRendering: [image0, image1, image2, image3])
+    }
+    
+    func test_loadFeedCompletion_rendersSuccessfullyLoadedEmptyFeedAfterNonEmptyFeed() {
+        let image0 = makeImage()
+        let image1 = makeImage()
+        let (sut, loader) = makeSUT()
+        
+        sut.loadViewIfNeeded()
+        loader.completeFeedLoading(with: [image0, image1], at: 0)
+        assertThat(sut, isRendering: [image0, image1])
+        
+        sut.simulateUserInitiatedFeedReload()
+        loader.completeFeedLoading(with: [], at: 1)
+        assertThat(sut, isRendering: [])
     }
     
     func test_loadFeedCompletion_doesNotAlterCurrentRenderingStateOnError() {

--- a/EssentialApp/EssentialAppTests/Helpers/FeedUIIntegrationTests+Assertions.swift
+++ b/EssentialApp/EssentialAppTests/Helpers/FeedUIIntegrationTests+Assertions.swift
@@ -11,8 +11,7 @@ import EssentialFeediOS
 
 extension FeedUIIntegrationTests {
     func assertThat(_ sut: FeedViewController, isRendering feed: [FeedImage], file: StaticString = #filePath, line: UInt = #line) {
-        sut.tableView.layoutIfNeeded()
-        RunLoop.main.run(until: Date())
+        sut.view.enforceLayoutCycle()
         
         guard sut.numberOfRenderedFeedImageViews() == feed.count else {
             return XCTFail("Expected \(feed.count) images, got \(sut.numberOfRenderedFeedImageViews()) instead.")

--- a/EssentialApp/EssentialAppTests/Helpers/FeedUIIntegrationTests+Assertions.swift
+++ b/EssentialApp/EssentialAppTests/Helpers/FeedUIIntegrationTests+Assertions.swift
@@ -1,5 +1,5 @@
 //
-//  FeedViewControllerTests+Assertions.swift
+//  FeedUIIntegrationTests+Assertions.swift
 //  EssentialFeediOSTests
 //
 //  Created by Shibili Areekara on 14/02/22.
@@ -11,6 +11,8 @@ import EssentialFeediOS
 
 extension FeedUIIntegrationTests {
     func assertThat(_ sut: FeedViewController, isRendering feed: [FeedImage], file: StaticString = #filePath, line: UInt = #line) {
+        sut.tableView.layoutIfNeeded()
+        RunLoop.main.run(until: Date())
         
         guard sut.numberOfRenderedFeedImageViews() == feed.count else {
             return XCTFail("Expected \(feed.count) images, got \(sut.numberOfRenderedFeedImageViews()) instead.")

--- a/EssentialApp/EssentialAppTests/Helpers/UIView+TestHelpers.swift
+++ b/EssentialApp/EssentialAppTests/Helpers/UIView+TestHelpers.swift
@@ -1,0 +1,15 @@
+//
+//  UIView+TestHelpers.swift
+//  EssentialAppTests
+//
+//  Created by Shibili Areekara on 06/03/23.
+//
+
+import UIKit
+
+extension UIView {
+    func enforceLayoutCycle() {
+        layoutIfNeeded()
+        RunLoop.current.run(until: Date())
+    }
+}

--- a/EssentialFeed/EssentialFeediOS/Feed UI/Controllers/FeedViewController.swift
+++ b/EssentialFeed/EssentialFeediOS/Feed UI/Controllers/FeedViewController.swift
@@ -18,6 +18,8 @@ public final class FeedViewController: UITableViewController, UITableViewDataSou
     
     public var delegate: FeedViewControllerDelegate?
     
+    private var leadingControllers = [IndexPath: FeedImageCellController]()
+    
     private var tableModel = [FeedImageCellController]() {
         didSet { tableView.reloadData() }
     }
@@ -39,6 +41,7 @@ public final class FeedViewController: UITableViewController, UITableViewDataSou
     }
     
     public func display(_ cellControllers: [FeedImageCellController]) {
+        leadingControllers = [:]
         tableModel = cellControllers
     }
     
@@ -73,10 +76,13 @@ public final class FeedViewController: UITableViewController, UITableViewDataSou
     }
     
     private func cellController(forRowAt indexPath: IndexPath) -> FeedImageCellController {
-        return tableModel[indexPath.row]
+        let controller = tableModel[indexPath.row]
+        leadingControllers[indexPath] = controller
+        return controller
     }
     
     private func cancelCellControllerLoad(forRowAt indexPath: IndexPath) {
-        tableModel[indexPath.row].cancelLoad()
+        leadingControllers[indexPath]?.cancelLoad()
+        leadingControllers[indexPath] = nil
     }
 }


### PR DESCRIPTION
When updating the table model and reloading the table, UIKit calls `didEndDisplayingCell` for each removed cell that was previously visible. Since we're canceling requests in this method, we could be sending messages to the new models or potentially crashing in case the new table model has fewer items than the previous one!

This is not a big problem at the moment since items cannot be removed from the feed. But we cannot assume the backend will keep this behaviour going further.